### PR TITLE
Add missing border styles in default stylesheet

### DIFF
--- a/sass/components/_asciidoc.scss
+++ b/sass/components/_asciidoc.scss
@@ -739,25 +739,62 @@ table.spread {
   width: 100%;
 }
 
-// NOTE .grid-* must be defined before .frame-* for styles to cascade properly
-table.grid-all {
-  border-collapse: separate;
-  border-spacing: 1px;
-  @include radius;
-  border-top: $table-border-highlight-size solid $table-border-highlight-color;
-  border-bottom: $table-border-highlight-size solid $table-border-highlight-color;
+// NOTE .grid-* selectors must be defined before .frame-* selectors in order for styles to cascade properly
+table.tableblock,
+th.tableblock,
+td.tableblock {
+  border: 0 solid $table-border-color;
 }
 
-table.frame-topbot,
-table.frame-none {
-  border-left: 0;
-  border-right: 0;
+table.grid-all th.tableblock,
+table.grid-all td.tableblock {
+  border-width: 0 $table-border-size $table-border-size 0;
 }
 
-table.frame-sides,
-table.frame-none {
-  border-top: 0;
-  border-bottom: 0;
+table.grid-all tfoot > tr > th.tableblock,
+table.grid-all tfoot > tr > td.tableblock {
+  border-width: $table-border-size $table-border-size 0 0;
+}
+
+table.grid-cols th.tableblock,
+table.grid-cols td.tableblock {
+  border-width: 0 $table-border-size 0 0;
+}
+
+table.grid-all * > tr > .tableblock:last-child,
+table.grid-cols * > tr > .tableblock:last-child {
+  border-right-width: 0;
+}
+
+table.grid-rows th.tableblock,
+table.grid-rows td.tableblock {
+  border-width: 0 0 $table-border-size 0;
+}
+
+table.grid-all tbody > tr:last-child > th.tableblock,
+table.grid-all tbody > tr:last-child > td.tableblock,
+table.grid-all thead:last-child > tr > th.tableblock,
+table.grid-rows tbody > tr:last-child > th.tableblock,
+table.grid-rows tbody > tr:last-child > td.tableblock,
+table.grid-rows thead:last-child > tr > th.tableblock {
+  border-bottom-width: 0;
+}
+
+table.grid-rows tfoot > tr > th.tableblock,
+table.grid-rows tfoot > tr > td.tableblock {
+  border-width: $table-border-size 0 0 0;
+}
+
+table.frame-all {
+  border-width: $table-border-size;
+}
+
+table.frame-sides {
+  border-width: 0 $table-border-size;
+}
+
+table.frame-topbot {
+  border-width: $table-border-size 0;
 }
 
 @each $halign in (left, right, center) {


### PR DESCRIPTION
This is for asciidoctor/asciidoctor#569.

I've never used sass before and I'm by no means a CSS expert so bare with me. It took a little trial and error to get things looking OK. I'm pretty happy with how it turned out and tables look a heck of a lot better in print view too. Other than copying the styles verbatim from epub3.css, there are a few small changes worth pointing out here:

1) I added a CSS selector block not found in epub3.css to avoid the `grid-all` class from adding a border on the right side of the table. My guess was that the `grid-all` class was intended to only style inner borders and the `frame-all` class to only style outer ones? The issue this addresses was noticeable when `frame-none` and `grid-all` were used in combination. If this is desired we may want to apply this fix to epub3.css too.

`table.grid-all td:last-child {
 border-right-width: 0;
}`

2) I tried to be clever and use the sass variables `$table-border-highlight-size` and `$table-border-highlight-color`. One consequence of this is that the color is `#dddddd` rather than `#80807F` if I had copied verbatim from the epub3.css.

3) Lastly I removed the original `table.grid-all` selector block that among other things was rounding the table corners. I noticed it wasn't used in epub3.css and it was causing me some grief so I got rid of it.

Let me know what you think. If any of this requires fixing up let me know. 

I suspect once this is merged we'll want a PR that copies the generated `asciidoctor.css` into the asciidoctor project?
