### PR TITLE
Modify code selector to accommodate Prettify

### DIFF
--- a/sass/components/_asciidoc.scss
+++ b/sass/components/_asciidoc.scss
@@ -68,7 +68,7 @@ body {
   }
 }
 
-*:not(pre) > code {
+*:not(pre) > code:not([data-attr]) {
   font-size: $code-font-size;
   font-style: normal !important;
   letter-spacing: 0;


### PR DESCRIPTION
The prettify source highlighter wraps the `<code>` element in an ordered
list. This causes the lines to be decorated in the same way as inline
monospaced text, which looks ugly when using the default stylesheet. Add
special styles for prettify that prevent the nested `<code>` element from
being styled.

We currently use `*:not(pre)>code` in the default stylesheet to style code
inside prose. However, prettify breaks this assumption by putting an
element (several) between the pre and code (unlike all the other syntax
highlighters).

This fix is fairly safe, accommodates the above, and as opposed to using
classes, any necessary refactoring in the future will only involve
changing this selector as opposed to changes in both markup and CSS.
