### PR TITLE
use unbolded roman for multiple emphasis and strong

### DIFF
--- a/sass/components/_asciidoc.scss
+++ b/sass/components/_asciidoc.scss
@@ -116,6 +116,16 @@ pre, pre > code {
 //  border: 0;
 //}
 
+em em {
+  font-style: normal;
+  line-height: inherit;
+}
+
+strong strong {
+  font-weight: normal;
+  line-height: inherit;
+}
+
 .keyseq {
   color: lighten($body-font-color, 20%);
 }


### PR DESCRIPTION
The typical typographic presentation for “doubled” italics or bold is plain roman text.  Compass doesn't provide this for us, so provide it ourselves.  This makes it possible to render, for example, emphasized words in a run of foreign text.