### PR TITLE
build-stylesheet.sh: Support bash in any location

### DIFF
--- a/build-stylesheet.sh
+++ b/build-stylesheet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 STYLESHEET_NAME=asciidoctor
 


### PR DESCRIPTION
Hi, first of all, thanks for creating asciidoctor, it's pretty neat!

To quote https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

/usr/bin/env searches PATH for bash, and bash is not always
in /bin, particularly on non-Linux systems. For example, on
my OpenBSD system, it's in /usr/local/bin, since it was
installed as an optional package.