### PR TITLE
Correcting the README -- it says pass the -g flag to npm install, but…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ The default stylesheet is generated using the [.path]_build-stylesheet.sh_ comma
 To run this command, you need the following programs:
 
 * bundler (`gem install bundler`)
-* cssshrink (`npm install -g cssshrink`)
+* cssshrink (`npm install cssshrink`)
 * cat
 * sed
 * ruby


### PR DESCRIPTION
… ./build-stylesheet.sh only works if npm install has been run without the -g flag.

(If you check the path in build-stylesheet.sh it looks in ./node_modules for cssshrink, but the -g flag on installation puts it in a global location.)