### PR TITLE
Define a style for defmastership

### DIFF
--- a/sass/defmastership.scss
+++ b/sass/defmastership.scss
@@ -1,0 +1,31 @@
+@import "settings/asciidoctor";
+@import "components/awesome-icons";
+
+@import "settings/defmastership";
+@import "maker";
+
+
+.define .content, .define>p {
+    @include single-box-shadow($definition-border-color, 0, 1px, 4px);
+}
+
+.tag {
+    border: none;
+    height: 100%;
+    border-radius: 4px;
+    box-sizing: border-box;
+    padding: 0 4px;
+    font-family: Roboto,RobotoDraft,Helvetica,Arial,sans-serif;
+}
+
+@each $color in ('aqua', 'black', 'blue', 'fuchsia', 'gray', 'green', 'lime', 'maroon', 'navy', 'olive', 'purple', 'red', 'silver', 'teal', 'white', 'yellow') {
+    .tag.#{$color} {
+        color: white;
+        background-color: scale-color(string-to-color($color), $lightness: $rainbow-lightness);
+
+    }
+}
+
+.external_reference a {
+    font-style: italic;
+}

--- a/sass/settings/_defmastership.scss
+++ b/sass/settings/_defmastership.scss
@@ -1,0 +1,1 @@
+$definition-border-color: black;


### PR DESCRIPTION
asciidoctor-defmastership is a Preprocessor Asciidoctor extension that
allow to set definition with reference as follow:

[define, requirement, REF-0001]
--
Exemple of more paragraphs.

Second Paragrap.
--

See : https://gitlab.com/jjag/asciidoctor-defmastership and https://gitlab.com/jjag/defmastership